### PR TITLE
Fix initialization dictionary formatting

### DIFF
--- a/client/oracle_mcp_client.py
+++ b/client/oracle_mcp_client.py
@@ -59,7 +59,7 @@ class MCPStdioClient:
                 "name": "oracle-mcp-client",
                 "version": "1.0.0"
             }
-   eibccdcbh     })
+        })
         
         print(f"Initialize result received")
         


### PR DESCRIPTION
## Summary
- remove stray text from initialization request in `start_server`

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/Users/aryangosaliya/Desktop/oracle-mcp-server')*

------
https://chatgpt.com/codex/tasks/task_e_689560036ce8832fae4b41865fb7b22a