### PR TITLE
Use safe JSON parsing for tool parameters

### DIFF
--- a/client/oracle_mcp_client.py
+++ b/client/oracle_mcp_client.py
@@ -241,8 +241,11 @@ When answering the user's question:
                     if " with parameters:" in tool_part:
                         tool_name = tool_part.split(" with parameters:")[0].strip()
                         params_str = tool_part.split(" with parameters:")[1].strip()
-                        # Simple parameter parsing (you might want to make this more robust)
-                        params = eval(params_str) if params_str.startswith('{') else {}
+                        # Parse parameters safely as JSON
+                        try:
+                            params = json.loads(params_str)
+                        except json.JSONDecodeError:
+                            params = {}
                     else:
                         tool_name = tool_part.strip()
                         params = {}


### PR DESCRIPTION
## Summary
- replace `eval` with safe `json.loads` in client tool parameter parsing

## Testing
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/Users/aryangosaliya/Desktop/oracle-mcp-server')*


------
https://chatgpt.com/codex/tasks/task_e_68956004fc14832f934473a723e7f8bd