### PR TITLE
feat: make server path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ mcp dev main.py
 mcp install main.py
 ```
 
+### Configuring MCP_SERVER_PATH
+
+The included chat client looks for the server script at `server/main.py` by default. To point the client at a different server location, set the `MCP_SERVER_PATH` environment variable:
+
+```bash
+export MCP_SERVER_PATH=/path/to/server/main.py
+```
+
 ### Available Tools
 
 When connected to an AI assistant like GitHub Copilot in VSCode Insiders or Claude, the following tools will be available:

--- a/client/oracle_mcp_client.py
+++ b/client/oracle_mcp_client.py
@@ -271,7 +271,7 @@ When answering the user's question:
 
 async def main():
     """Main chat loop"""
-    server_script = "/Users/aryangosaliya/Desktop/oracle-mcp-server/server/main.py"
+    server_script = os.getenv("MCP_SERVER_PATH", "server/main.py")
     
     # Initialize MCP client
     print("🚀 Starting Oracle MCP Chat Client...")

--- a/simple_test.py
+++ b/simple_test.py
@@ -21,16 +21,19 @@ def test_oracle_mcp_server():
     os.environ['CACHE_DIR'] = '.cache'
     
     print("✅ Environment variables set")
-    
+
     # Start the server process
     print("🚀 Starting MCP server...")
+    server_script = os.getenv("MCP_SERVER_PATH", "server/main.py")
+    server_dir = os.path.dirname(server_script)
+    script_name = os.path.basename(server_script)
     process = subprocess.Popen(
-        ['uv', 'run', 'main.py'],
+        ['uv', 'run', script_name],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-        cwd='/Users/aryangosaliya/Desktop/oracle-mcp-server'
+        cwd=server_dir
     )
     
     # Wait for initialization


### PR DESCRIPTION
## Summary
- make client server path configurable with MCP_SERVER_PATH env var
- document MCP_SERVER_PATH usage in README
- update simple_test to honor MCP_SERVER_PATH

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68956005cf9c832fb144828a6fb1beb7