### PR TITLE
Simplify server healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     ports:
       - "8765:8765"
     healthcheck:
-      test: ["CMD-SHELL", "python - <<'PY'\nimport asyncio, websockets\nasync def t():\n  async with websockets.connect('ws://127.0.0.1:8765'): pass\nasyncio.run(t())\nPY"]
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8765),3); s.close()"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary
- replace websockets-based health check with simple socket connection

## Testing
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/Users/aryangosaliya/Desktop/oracle-mcp-server')*

------
https://chatgpt.com/codex/tasks/task_e_68968480b284832f84bf5b099da2326e