### PR TITLE
Use dedicated websocket healthcheck script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     ports:
       - "8765:8765"
     healthcheck:
-      test: ["CMD-SHELL", "python - <<'PY'\nimport asyncio, websockets\nasync def t():\n  async with websockets.connect('ws://127.0.0.1:8765'): pass\nasyncio.run(t())\nPY"]
+      test: ["CMD", "python", "server/healthcheck.py"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/server/healthcheck.py
+++ b/server/healthcheck.py
@@ -1,0 +1,9 @@
+import asyncio
+import websockets
+
+async def check():
+    async with websockets.connect("ws://127.0.0.1:8765"):
+        pass
+
+if __name__ == "__main__":
+    asyncio.run(check())


### PR DESCRIPTION
## Summary
- add `server/healthcheck.py` that opens and closes a WebSocket connection
- invoke the new script from the server container healthcheck

## Testing
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/Users/aryangosaliya/Desktop/oracle-mcp-server')*

------
https://chatgpt.com/codex/tasks/task_e_68968480b284832f84bf5b099da2326e